### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Bushido Blocks
 
-##Description
+## Description
 A fast-paced block slicing puzzle game inspired by block-bashing games such as Bejeweled, Diamond Dash and Tap Blox.
 
 Google Play: https://play.google.com/store/apps/details?id=com.me.drop&hl=en
 
-##Rules
+## Rules
 Tap matches of three or more blocks to slice them with your katana. The more blocks you can slice in one go, the more time you gain on the clock. Special blocks eliminate whole rows of blocks but don't give you any extra time, so use them wisely.
 
-##Thanks to
+## Thanks to
 * Music: Professor Kliq "Crystals"
 http://www.jamendo.com/en/track/925495/crystals
 http://www.professorkliq.com/
@@ -16,6 +16,6 @@ http://www.professorkliq.com/
 * Uses LibGDX framework http://libgdx.badlogicgames.com/
 * Leaderboards via Swarm http://swarmconnect.com/
 
-##Licenses
+## Licenses
 * Code: http://www.gnu.org/licenses/gpl.html
 * Music: CC BY SA http://creativecommons.org/licenses/by-sa/2.0/


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
